### PR TITLE
Added originProductId to CustomProduct, updated database schema, and implemented updateDay endpoint

### DIFF
--- a/src/main/java/com/github/veccvs/fitappv5/product/CustomProduct.java
+++ b/src/main/java/com/github/veccvs/fitappv5/product/CustomProduct.java
@@ -17,4 +17,5 @@ public class CustomProduct {
   private String sugar;
   private String weight;
   private String calories;
+  private Long originProductId;
 }

--- a/src/main/java/com/github/veccvs/fitappv5/user/day/UserDayController.java
+++ b/src/main/java/com/github/veccvs/fitappv5/user/day/UserDayController.java
@@ -20,7 +20,7 @@ public class UserDayController {
     return ResponseEntity.ok(userDayService.createUserDay(date));
   }
 
-  @PutMapping
+  @PutMapping("/product")
   public ResponseEntity<UserDay> addProductToDay(
       @RequestParam Integer userDayId,
       @RequestParam DayTime dayTime,
@@ -34,6 +34,11 @@ public class UserDayController {
       @RequestParam DayTime dayTime,
       @RequestBody List<CustomProduct> customProducts) {
     return ResponseEntity.ok(userDayService.addProductsToDay(userDayId, dayTime, customProducts));
+  }
+
+  @PutMapping
+  public ResponseEntity<UserDay> updateDay(@RequestBody UserDay userDay) {
+    return ResponseEntity.ok(userDayService.updateDay(userDay));
   }
 
   @GetMapping

--- a/src/main/java/com/github/veccvs/fitappv5/user/day/UserDayService.java
+++ b/src/main/java/com/github/veccvs/fitappv5/user/day/UserDayService.java
@@ -78,4 +78,8 @@ public class UserDayService {
 
     return getDayById(userDayId);
   }
+
+  public UserDay updateDay(UserDay userDay) {
+    return userDayRepository.save(userDay);
+  }
 }

--- a/src/main/resources/db/changelog/2024/06/21-01-changelog.xml
+++ b/src/main/resources/db/changelog/2024/06/21-01-changelog.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<databaseChangeLog
+        xmlns="http://www.liquibase.org/xml/ns/dbchangelog"
+        xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+        xsi:schemaLocation="http://www.liquibase.org/xml/ns/dbchangelog
+                      http://www.liquibase.org/xml/ns/dbchangelog/dbchangelog-4.24.xsd"
+        objectQuotingStrategy="QUOTE_ONLY_RESERVED_WORDS">
+    <changeSet id="1718985429001-1" author="jacekdalmer">
+        <addColumn tableName="user_day_breakfast_products">
+            <column name="origin_product_id" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+    <changeSet id="1718985429001-2" author="jacekdalmer">
+        <addColumn tableName="user_day_lunch_products">
+            <column name="origin_product_id" type="BIGINT"/>
+        </addColumn>
+    </changeSet>
+
+</databaseChangeLog>


### PR DESCRIPTION
1. Added a new field `originProductId` to the `CustomProduct` class to store the ID of the original product.
2. Updated the database schema to include the `origin_product_id` column in the `user_day_breakfast_products` and `user_day_lunch_products` tables.
3. Implemented a new `updateDay` endpoint in the `UserDayController` to allow updating a `UserDay` object.
4. Added the corresponding `updateDay` method in the `UserDayService` to handle the update logic and save the `UserDay` object to the repository.